### PR TITLE
Remove Type Conversion from Test Executor Class

### DIFF
--- a/src/CodingMonkey.CodeExecutor/CodeExecution/TestExecutor.cs
+++ b/src/CodingMonkey.CodeExecutor/CodeExecution/TestExecutor.cs
@@ -1,10 +1,11 @@
-﻿namespace CodingMonkey.CodeExecutor.CodeExecution
+﻿using Serilog;
+
+namespace CodingMonkey.CodeExecutor.CodeExecution
 {
     using CodingMonkey.Models;
     using CodingMonkey.CodeExecutor.Models;
     using Structs;
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
 
     public static class TestExecutor
@@ -12,23 +13,27 @@
         public static async Task RunTest(string code, CodeTemplate template, Test test, ResultSummary resultSummary)
         {
             var compiler = new RoslynCompiler();
-            if (!ConvertInputValueToValueType(test.Inputs))
-            {
-                resultSummary.ErrorProcessingTests = true;
-            }
-            else
+
+            try
             {
                 ExecutionResult result = await compiler.SanitiseCodeAndExecuteAsync(code, template.ClassName, template.MainMethodName, test.Inputs);
                 ProcessTestResult(result, test, resultSummary);
+            }
+            catch (Exception e)
+            {
+                Log.Logger.Error(e, "Failed to run test");
+                resultSummary.ErrorProcessingTests = true;
+                throw;
             }
         }
 
         private static void ProcessTestResult(ExecutionResult result, Test testRun, ResultSummary resultSummary)
         {
+            resultSummary.CompilerErrors = null;
+            resultSummary.HasCompilerErrors = false;
+
             if (!result.Successful)
             {
-                resultSummary.CompilerErrors = null;
-                resultSummary.HasCompilerErrors = false;
                 resultSummary.HasRuntimeError = true;
 
                 resultSummary.RuntimeError = new RuntimeError()
@@ -39,133 +44,10 @@
             }
 
             testRun.ActualOutput = result.Value;
-            if (!AddTestResult(testRun))
-            {
-                resultSummary.ErrorProcessingTests = true;
-            }
-        }
+            testRun.Result = new TestResult { TestExecuted = true };
 
-        private static bool ConvertInputValueToValueType(List<TestInput> testInputs)
-        {
-            foreach (var input in testInputs)
-            {
-                switch (input.ValueType)
-                {
-                    case "String":
-                        {
-                            return GetValueFromTestInput<string>(input);
-                        }
-                    case "Integer":
-                        {
-                            return GetValueFromTestInput<int>(input);
-                        }
-                    case "Boolean":
-                        {
-                            return GetValueFromTestInput<bool>(input);
-                        }
-                    default:
-                        {
-                            return false;
-                        }
-                }
-            }
-
-            return false;
-        }
-
-        private static bool GetValueFromTestInput<T>(TestInput input)
-        {
-            object value = GetValue<T>(input.Value);
-            if (value == null)
-            {
-                return false;
-            }
-            else
-            {
-                input.Value = (T)value;
-                return true;
-            }
-        }
-
-        private static bool AddTestResult(Test test)
-        {
-            test.Result = new TestResult { TestExecuted = true };
-
-            switch (test.ExpectedOutput.ValueType)
-            {
-                case "String":
-                    {
-                        return AddResultToTestResult<string>(test);
-                    }
-                case "Integer":
-                    {
-                        return AddResultToTestResult<int>(test);
-                    }
-                case "Boolean":
-                    {
-                        return AddResultToTestResult<bool>(test);
-                    }
-                default:
-                    {
-                        return false;
-                    }
-            }
-        }
-
-        private static bool AddResultToTestResult<T>(Test test)
-        {
-            try
-            {
-                var value = GetValue<T>(test.ExpectedOutput.Value);
-                test.ExpectedOutput.Value = (T)value;
-
-                test.Result.TestPassed = value.Equals((T)test.ActualOutput);
-
-                return true;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-
-        private static object GetValue<T>(object value)
-        {
-            switch (typeof(T).ToString())
-            {
-                case "System.String":
-                    {
-                        return value.ToString();
-                    }
-                case "System.Int32":
-                    {
-                        int inputValue;
-                        bool success = int.TryParse(value.ToString(), out inputValue);
-
-                        if (success)
-                        {
-                            return inputValue;
-                        }
-
-                        return null;
-                    }
-                case "System.Boolean":
-                    {
-                        bool inputValue;
-                        bool success = bool.TryParse(value.ToString(), out inputValue);
-
-                        if (success)
-                        {
-                            return inputValue;
-                        }
-
-                        return null;
-                    }
-                default:
-                    {
-                        return null;
-                    }
-            }
+            testRun.ExpectedOutput.Value = testRun.ExpectedOutput.Value.ToString();
+            testRun.Result.TestPassed = testRun.ExpectedOutput.Value.ToString().Equals(testRun.ActualOutput.ToString());
         }
     }
 }


### PR DESCRIPTION
Type conversion was used by the test executor to convert from often string representations of a value stored in an object to the concrete type.

However:

1. This never worked as I expected - only converting the first input in every test run.
2. It is not needed to make the type conversion for a test run to work.

Because of point two I never noticed point one. In brief - no matter how the types are stored in the system the code execution is always done as a string and the so is the value comparison. So you only ever need to work with strings. 

This could get more complicated as I look to add array support. But even at that point, the array would still need to be passed to Rosyln as an argument something like this:

```
"MyMethod(new int Array[2] {1, 2}, \"some other arg\");"
```

So even with more complex types the only type of conversion which should ever be needed is complex type ---> string code equivalent.