### PR TITLE
Remove the Type type from the allowed types list

### DIFF
--- a/src/CodingMonkey.CodeExecutor/Security/SecurityLists.cs
+++ b/src/CodingMonkey.CodeExecutor/Security/SecurityLists.cs
@@ -85,7 +85,6 @@
                     "SynchronizedReadOnlyCollection`1",
                     "TimeSpanFormat",
                     "TimeSpanParse",
-                    "Type",
                     "UInt16",
                     "UInt32",
                     "UInt64",


### PR DESCRIPTION
Type doesn't need to be on the list of allowed types... and can be used to bypass stuff e.g. Type.GetType(System.Environment)